### PR TITLE
Add support for Internet Explorer 10/11

### DIFF
--- a/src/parser/image_manager.js
+++ b/src/parser/image_manager.js
@@ -302,7 +302,7 @@ var ImageManager = {
 // use delayed evaluation just in case,
 // because Document#createElement() might be executed
 // before DOM is not initialized
-ImageManager.__defineGetter__("usePremultipliedAlpha", function() {
+defineGetter(ImageManager, "usePremultipliedAlpha", function () {
 	delete this.usePremultipliedAlpha;
 
 	var canvas = document.createElement("canvas");

--- a/src/parser/loader.js
+++ b/src/parser/loader.js
@@ -30,12 +30,16 @@ Loader.prototype.load = function(src, callback) {
 	
 	if(!this.option.swfBinary) {
 		var xhr = new XMLHttpRequest();
-		var isTypedArraySupported = window.DataView;
+		var isTypedArrayUint8Supported = window.DataView && window.DataView.prototype.getUint8;
+		var isXhrArrayBufferSupported = false;
 		xhr.open("GET", src);
-		if(isTypedArraySupported) {
-			// TypedArray supported
+		if(isTypedArrayUint8Supported && 'responseType' in xhr) { // TypedArray supported
 			xhr.responseType = 'arraybuffer';
-		} else {
+			if (xhr.responseType === 'arraybuffer') {
+				isXhrArrayBufferSupported = true;
+			}
+		}
+		if (!isXhrArrayBufferSupported) {
 			xhr.overrideMimeType('text/plain; charset=x-user-defined'); // binary
 		}
 		xhr.onreadystatechange = (function(that) {
@@ -47,7 +51,7 @@ Loader.prototype.load = function(src, callback) {
 				}
 				if(xhr.readyState >= 3) {
 					var len = 0;
-					if(isTypedArraySupported) {
+					if(isTypedArrayUint8Supported && isXhrArrayBufferSupported) {
 						if(xhr.response) {
 							var dataView = new DataView(xhr.response);
 							len = xhr.response.byteLength;

--- a/src/parser/utils_tag.js
+++ b/src/parser/utils_tag.js
@@ -19,7 +19,7 @@ var setProperty = function(obj, name, func, delayEval) {
 		return;
 	}
 	
-	obj.__defineGetter__(name, function(){
+	defineGetter(obj, name, function() {
 		delete this[name];
 		return this[name] = func();
 	});
@@ -37,7 +37,7 @@ var setProperties = function(obj, func, attributes, delayEval) {
 	var len = attributes.length;
 	for(var i = 0; i < len; i++) {
 		// set "FIRST" property
-		obj.__defineGetter__(attributes[i],
+		defineGetter(obj, attributes[i],
 			function(ownKey) {
 				return function() {
 					var result = func();

--- a/src/touch.js
+++ b/src/touch.js
@@ -32,9 +32,9 @@ var _Touch = function(engine) {
 			that.keyDown(e.keyCode);
 		}, false);
 	
-		if(!("ontouchstart" in document.body) && !("onpointerdown" in document.body)) {
+		if(!("ontouchstart" in document.body)) {
 			engine.option.debug && EngineLogD("PC browser mode detected");
-			this.addListener(engine.container, "mousedown", function (e) {
+			this.addListener(engine.container, "mousedown", function(e) {
 				that.touchStart.call(that, e);
 				e.preventDefault();
 			}, false);
@@ -46,33 +46,17 @@ var _Touch = function(engine) {
 				}
 			}, false);
 		}
-
-		if("ontouchstart" in document.body) {
-			this.addListener(engine.container, "touchstart", function(e) {
-				that.touchStart.call(that, e.touches[0]);
+		this.addListener(engine.container, "touchstart", function(e) {
+			that.touchStart.call(that, e.touches[0]);
+			e.preventDefault();
+		}, false);
+		this.addListener(document, "touchend", function(e) {
+			that.mouseRelease = {x: that.currentXY.x, y: that.currentXY.y};
+			if(that.isTouch) {
+				that.touchEnd.call(that, e);
 				e.preventDefault();
-			}, false);
-			this.addListener(document, "touchend", function(e) {
-				that.mouseRelease = {x: that.currentXY.x, y: that.currentXY.y};
-				if(that.isTouch) {
-					that.touchEnd.call(that, e);
-					e.preventDefault();
-				}
-			}, false);
-		} else {
-			this.addListener(engine.container, "pointerdown", function (e) {
-				that.touchStart.call(that, e);
-				e.preventDefault();
-			}, false);
-
-			this.addListener(document, "pointerup", function (e) {
-				that.mouseRelease = { x: that.currentXY.x, y: that.currentXY.y };
-				if (that.isTouch) {
-					that.touchEnd.call(that, e);
-					e.preventDefault();
-				}
-			}, false);
-		}
+			}
+		}, false);
 	}
 };
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -32,9 +32,9 @@ var _Touch = function(engine) {
 			that.keyDown(e.keyCode);
 		}, false);
 	
-		if(!("ontouchstart" in document.body)) {
+		if(!("ontouchstart" in document.body) && !("onpointerdown" in document.body)) {
 			engine.option.debug && EngineLogD("PC browser mode detected");
-			this.addListener(engine.container, "mousedown", function(e) {
+			this.addListener(engine.container, "mousedown", function (e) {
 				that.touchStart.call(that, e);
 				e.preventDefault();
 			}, false);
@@ -46,17 +46,33 @@ var _Touch = function(engine) {
 				}
 			}, false);
 		}
-		this.addListener(engine.container, "touchstart", function(e) {
-			that.touchStart.call(that, e.touches[0]);
-			e.preventDefault();
-		}, false);
-		this.addListener(document, "touchend", function(e) {
-			that.mouseRelease = {x: that.currentXY.x, y: that.currentXY.y};
-			if(that.isTouch) {
-				that.touchEnd.call(that, e);
+
+		if("ontouchstart" in document.body) {
+			this.addListener(engine.container, "touchstart", function(e) {
+				that.touchStart.call(that, e.touches[0]);
 				e.preventDefault();
-			}
-		}, false);
+			}, false);
+			this.addListener(document, "touchend", function(e) {
+				that.mouseRelease = {x: that.currentXY.x, y: that.currentXY.y};
+				if(that.isTouch) {
+					that.touchEnd.call(that, e);
+					e.preventDefault();
+				}
+			}, false);
+		} else {
+			this.addListener(engine.container, "pointerdown", function (e) {
+				that.touchStart.call(that, e);
+				e.preventDefault();
+			}, false);
+
+			this.addListener(document, "pointerup", function (e) {
+				that.mouseRelease = { x: that.currentXY.x, y: that.currentXY.y };
+				if (that.isTouch) {
+					that.touchEnd.call(that, e);
+					e.preventDefault();
+				}
+			}, false);
+		}
 	}
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -66,3 +66,13 @@ var createDataStoreFromObject = function(obj, imageMap, onLoad) {
 
 	return dataStore;
 };
+
+var defineGetter = (function() {
+	return (Object.defineProperty && !Object.prototype.__defineGetter__)
+				? function(obj, name, func) {
+					Object.defineProperty(obj, name, { configurable: true, get: func });
+				}
+				: function(obj, name, func) {
+					obj.__defineGetter__(name, func);
+				}
+})();


### PR DESCRIPTION
バイナリ読み込み周りとプロパティ(getter)の定義を標準仕様に沿わせる形でInternet Explore 10と11での動作のサポートを追加します。

以下の環境で動作することを確認しています。
- Internet Explorer 10 (10.0.9200.16843) / Windows Server 2012 (Windows 8相当)
- Internet Explorer 11 (11.0.9600.17031) / Windows 8.1 Update & Windows RT 8.1 Update (Surface 2)
- Internet Explorer 11 for Windows Phone / Windows Phone 8.1 (Lumia 620)
