### PR TITLE
Added existence check function in case of "ActionDefine.TypeActionFSCommand2

### DIFF
--- a/src/vm.js
+++ b/src/vm.js
@@ -423,7 +423,7 @@ var createActionFunction = function(actions, debug) {
 		case ActionDefine.TypeActionFSCommand2:
 			body += "var size=stack.pop();var stackLen=stack.length;/**/";
 			body += "if(stack[stackLen-1]=='JavaScript'){/**/";
-			body += "var args=[];var jsFunc=eval(stack[stackLen-2]);stack.length-=2;var len=size-2;for(var i=0;i<len;i++){args[i]=stack.pop();}jsFunc.apply(null,args);stack[stack.length]=0;/**/";
+			body += "var args=[];var jsFuncName = stack[stackLen-2];var jsFunc=eval(jsFuncName);if(typeof jsFunc!=='function'){EngineLogW('Function \"'+jsFuncName+'\" does not exist in the global');stack.length-=size;stack[stack.length]=-1;}else{stack.length-=2;var len=size-2;for(var i=0;i<len;i++){args[i]=stack.pop();}jsFunc.apply(null,args);stack[stack.length]=0;}/**/";
 			body += "}else{stack.length-=size;stack[stack.length]=-1;}/**/";
 			break;
 		case ActionDefine.TypeActionTrace:
@@ -746,8 +746,24 @@ var createRawActionFunction = function(actions, debug) {
 			case ActionDefine.TypeActionFSCommand2:
 				var size=stack.pop();var stackLen=stack.length;
 				if(stack[stackLen-1]=='JavaScript'){
-				var args=[];var jsFunc=eval(stack[stackLen-2]);stack.length-=2;var argc=size-2;for(var j=0;j<argc;j++){args[j]=stack.pop();}jsFunc.apply(null,args);stack[stack.length]=0;
-				}else{stack.length-=size;stack[stack.length]=-1;}
+					var args=[];
+					var jsFuncName = stack[stackLen-2];
+					var jsFunc=eval(jsFuncName);
+					if(typeof jsFunc !== 'function'){
+						EngineLogW('Function "'+jsFuncName+'" does not exist in the global');
+						stack.length-=size;stack[stack.length]=-1;
+						break;
+					}
+					stack.length-=2;
+					var argc=size-2;
+					for(var j=0;j<argc;j++){
+						args[j]=stack.pop();
+					}
+					jsFunc.apply(null,args);
+					stack[stack.length]=0;
+				}else{
+					stack.length-=size;stack[stack.length]=-1;
+				}
 				break;
 			case ActionDefine.TypeActionTrace:
 				debug? EngineLogD("Trace: "+stack.pop()): stack.pop();


### PR DESCRIPTION
SWF 側から FSCommand2 を経由して JavaScript をコールした時、コールする対象の関数が存在しない場合に無限ループへ陥るバグを修正しました。
- function name を eval 評価した後、typeof で型をチェック
- 関数が存在しない場合は、stack を size 分減らし、-1 を追加(FSCommand2 に JavaScript が指定されなかった場合の処理と同一にした)
- createActionFunction 内では break 無しの switch, case の評価を行いながら関数を組み立てていたので、存在チェック後に break を行わず処理を続けるようにした 
