### PR TITLE
Feature/force disable blend mode

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -93,6 +93,10 @@ Engine.prototype.initialize = function() {
 	this.renderCount = 0;
 	// don't play if option is set
 	this.running = !option.stopOnStart;
+
+	// get rid of "darker" in globalCompositeOperation
+	// https://code.google.com/p/chromium/issues/detail?id=136830
+	overrideTransformImageColorFunction(option.forceDisableBlendMode, option.debug);
 };
 
 Engine.prototype.dataStoreProgress = function() {

--- a/src/option.js
+++ b/src/option.js
@@ -40,5 +40,6 @@ var defaultOption = {
 	enableStyleText: false,
 	_enableWorkaroundForUnicolor: false,  // experimental
 	colorLevels: 16,
-	swfBinary: null
+	swfBinary: null,
+	forceDisableBlendMode: false // experimental
 };

--- a/src/renderer/util_render.js
+++ b/src/renderer/util_render.js
@@ -421,6 +421,9 @@ var overrideTransformImageColorFunction = function(forceDisableBlendMode, verbos
 			EngineLogW("overrideTransformImageColorFunction");
 		}
 	}
+
+	// hollowing
+	overrideTransformImageColorFunction = function() {};
 };
 
 var transformImageColor = (function() {

--- a/src/renderer/util_render.js
+++ b/src/renderer/util_render.js
@@ -246,6 +246,183 @@ var cacheTransformImageColor = function(cacheController) {
 	}
 };
 
+var transformImageColorUsingBlendMode = function(cxformList, img) {
+	// return if the image has not been drawn yet
+	if(!img.width) {
+		return img;
+	}
+
+	var len = cxformList.length;
+	if(!len) {
+		return img;
+	}
+
+	var w = img.width;
+	var h = img.height;
+
+	var output = transformImageColor.output || (transformImageColor.output = CacheController.getFreeCanvas());
+	output.width = w;
+	output.height = h;
+	var octx = output.getContext("2d");
+
+	if(cxformList.length === 1) {
+		var cxform = cxformList[0];
+		if(cxform[0] === 256 && cxform[1] === 256 && cxform[2] === 256 && cxform[4] === 0 && cxform[5] === 0 && cxform[6] === 0) {
+			octx.globalAlpha = cxform[3] / 256;
+			octx.drawImage(img, 0, 0);
+			// Ignore cxform[7] same as original transformImageColor for the performance
+			// (I think this is a bug)
+			return output;
+		}
+	}
+	octx.drawImage(img, 0, 0);
+
+	// Remove transparency to process RGB channel and alpha channel separately
+	// (blend-mode seems to remove transparency)
+	octx.globalCompositeOperation = "multiply";
+	octx.fillStyle = "rgba(255,255,255,1)";
+	octx.fillRect(0, 0, w, h);
+
+	var alphaCanvas = transformImageColor.alphaCanvas || (transformImageColor.alphaCanvas = CacheController.getFreeCanvas());
+	alphaCanvas.width = w;
+	alphaCanvas.height = h;
+	var actx = alphaCanvas.getContext("2d");
+	actx.drawImage(img, 0, 0);
+	actx.globalCompositeOperation = "source-atop";
+	actx.fillStyle = "rgba(255,255,255,1)";
+	actx.fillRect(0, 0, w, h);
+
+	for(var j = len - 1; j >= 0; j--) {
+		var cxform = cxformList[j];
+
+		// Multiply colors
+		var rgbcolors = [];
+		var colorChanged = false;
+		for(var colorIndex = 0; colorIndex < 3; colorIndex++) {
+			if(cxform[colorIndex] != 256) {
+				colorChanged = true;
+			}
+			rgbcolors.push(cxform[colorIndex] / 256 * 255 | 0);
+		}
+		if(colorChanged) {
+			octx.globalCompositeOperation = "multiply";
+			octx.fillStyle = "rgb(" + rgbcolors.join() + ")";
+			octx.fillRect(0, 0, w, h);
+		}
+
+		// Add colors
+		var addedColors = [];
+		var hasAdded = false;
+		var subtractedColors = [];
+		var hasSubtracted = false;
+		for(var colorIndex = 4; colorIndex < 7; colorIndex++) {
+			var colorVal = cxform[colorIndex];
+			if(colorVal === 0) {
+				addedColors.push(0);
+				subtractedColors.push(0);
+			} else if(colorVal > 0) {
+				addedColors.push(colorVal);
+				subtractedColors.push(0);
+				hasAdded = true;
+			} else {
+				addedColors.push(0);
+				subtractedColors.push(-colorVal);
+				hasSubtracted = true;
+			}
+		}
+
+		if(hasAdded) {
+			octx.globalCompositeOperation = "lighter";
+			octx.fillStyle = "rgba(" + addedColors.join() + ",1)";
+			octx.fillRect(0, 0, w, h);
+		}
+		if(hasSubtracted) {
+			octx.globalCompositeOperation = "difference";
+			octx.fillStyle = "rgba(255,255,255,1)";
+			octx.fillRect(0, 0, w, h);
+
+			octx.globalCompositeOperation = "lighter";
+			octx.fillStyle = "rgba(" + subtractedColors.join() + ",1)";
+			octx.fillRect(0, 0, w, h);
+
+			octx.globalCompositeOperation = "difference";
+			octx.fillStyle = "rgba(255,255,255,1)";
+			octx.fillRect(0, 0, w, h);
+		}
+
+		// Transform alpha
+		if(cxform[3] < 256) {
+			actx.globalCompositeOperation = "destination-in";
+			actx.globalAlpha = cxform[3] / 256;
+			actx.fillRect(0, 0, w, h);
+		}
+		if(cxform[7]) {
+			// maybe work well but not supported
+			// (the case where cxform[7] is a negative value is not supported)
+			if(cxform[7] > 0) {
+				actx.globalCompositeOperation = "lighter";
+				actx.globalAlpha = cxform[7] / 255; // cxform[7] == addAlpha
+				actx.fillRect(0, 0, w, h);
+			}
+			EngineLogW("[transformImageColor] addAlpha detected. not support");
+		}
+	}
+
+	// alpha mask
+	octx.globalCompositeOperation = "destination-in";
+	octx.globalAlpha = 1;
+	octx.drawImage(alphaCanvas, 0, 0);
+	return output;
+};
+
+var getChromeVersion = function(userAgent) {
+	if (/Chrome\//.test(userAgent)) {
+		return parseFloat(userAgent.split("Chrome/")[1]);
+	}
+	return 0;
+};
+
+var getMobileSafariVersion = function(userAgent) {
+	if (/(iPhone|iPad|iPod)/.test(userAgent) && /Safari\//.test(userAgent)) {
+		return parseFloat(userAgent.split("Version/")[1]);
+	}
+	return 0;
+};
+
+var isEnableBlendModeFunctions = function() {
+	// Canvas blend modes supports
+	//  - Chrome 30 and later
+	//  - Mobile Safari 7.1 and later
+	// in caniuse.com
+	var ctx = document.createElement("canvas").getContext("2d");
+
+	return ["difference", "multiply"].every(function(blendMode) {
+		ctx.globalCompositeOperation = blendMode; // try
+		return ctx.globalCompositeOperation === blendMode; // verify
+	});
+};
+
+var overrideTransformImageColorFunction = function(forceDisableBlendMode, verbose) {
+	var override = false;
+
+	if (isEnableBlendModeFunctions()) {
+		if (getChromeVersion(navigator.userAgent) >= 40 ||
+			getMobileSafariVersion(navigator.userAgent) >= 8.0) {
+			override = true;
+
+			if (forceDisableBlendMode) {
+				override = false;
+			}
+		}
+	}
+	if (override) {
+		transformImageColor = transformImageColorUsingBlendMode;
+		if (verbose) {
+			EngineLogW("overrideTransformImageColorFunction");
+		}
+	}
+};
+
 var transformImageColor = (function() {
 	// don't define `splitRegion` not to call a function for the performance if not required
 	// cf. http://jsperf.com/call-a-function-vs-assign-a-return-value-directly


### PR DESCRIPTION
This pull request is intended to solve the following problem.

- [Remove darker composite operator](https://www.chromestatus.com/feature/5712397973061632)

And options.forceDisableBlendMode will be available by incorporating this change.
This option is emergency switch.