### PR TITLE
canvas.style.zoomを利用した際にタッチイベントの座標がずれる問題を修正

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -65,7 +65,7 @@ _Touch.prototype.getPositionFromEvent = function(e) {
 	var y = e.pageY;
 	var r = this.engine.container.style.zoom;
 	if(r) {
-		var ratio = r.substring(0, r.length - 1) / 100;
+		var ratio = r.substring(0, r.length - 1);
 		x /= ratio;
 		y /= ratio;
 	}


### PR DESCRIPTION
canvasをzoomした際に、タッチイベントの位置がずれる問題がありましたので修正しました。
