### PR TITLE
テキストの行間をマイナス指定した場合に2行目以降がcanvas外になってしまうバグを修正

### DIFF
--- a/src/parser/tag_font_text.js
+++ b/src/parser/tag_font_text.js
@@ -316,7 +316,7 @@ var TagDefineEditText = function(binary, pos, length, type, delayEval, dataStore
 			p += 2;
 			result.indent = getUI16(binary, p);
 			p += 2;
-			result.leading = getUI16(binary, p);
+			result.leading = getSI16(binary, p);
 			p += 2;
 		}
 		result.variableName = getString(binary, p);


### PR DESCRIPTION
テキストの行間をマイナス指定した場合に2行目以降がcanvas外になってしまうバグを修正

SI16かUI16の勘違いかと思います。

参考
http://wwwimages.adobe.com/www.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf

> FontLeading
> If FontFlagsHasLayout, SI16
> Font leading height (see following).
